### PR TITLE
Fixed broken link to Flying Saucer website

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -3,7 +3,7 @@ acts\_as\_flying\_saucer
 
 acts\_as\_flying\_saucer is a library that allows to save rendered views as pdf documents using the [Flying Saucer][1] java library.
 
-[1]: https://xhtmlrenderer.dev.java.net/
+[1]: https://code.google.com/p/flying-saucer/
 
 Install
 -------


### PR DESCRIPTION
https://xhtmlrenderer.dev.java.net/ does not resolve. First result on Google is http://xhtmlrenderer.java.net/ but that page says project has moved to https://code.google.com/p/flying-saucer/.
