### PR TITLE
Apply max_memory_mb setting to PDF generation

### DIFF
--- a/lib/acts_as_flying_saucer/xhtml2pdf.rb
+++ b/lib/acts_as_flying_saucer/xhtml2pdf.rb
@@ -21,7 +21,7 @@ module ActsAsFlyingSaucer
 			if options[:nailgun]
 				command = "#{Nailgun::NgCommand::NGPATH} --nailgun-server #{ActsAsFlyingSaucer::Config.options[:nailgun_host]}  --nailgun-port #{ ActsAsFlyingSaucer::Config.options[:nailgun_port]} Xhtml2Pdf #{options[:input_file]} #{options[:output_file]}"
 			else
-				command = "#{options[:java_bin]} -Xmx512m -Djava.awt.headless=true -cp #{class_path} acts_as_flying_saucer.Xhtml2Pdf #{options[:input_file]} #{options[:output_file]}"
+				command = "#{options[:java_bin]} -Xmx#{options[:max_memory_mb]}m -Djava.awt.headless=true -cp #{class_path} acts_as_flying_saucer.Xhtml2Pdf #{options[:input_file]} #{options[:output_file]}"
 			end
 			system(command)
 		end


### PR DESCRIPTION
The max_memory_mb setting is only applied to the encryption of PDFs -- This PR applies it to the generation as well
